### PR TITLE
Avoid NullReferenceException in DataGridView.

### DIFF
--- a/src/Controls/OutlookGrid/DataSourceManager.cs
+++ b/src/Controls/OutlookGrid/DataSourceManager.cs
@@ -77,6 +77,9 @@ namespace Xnlab.SQLMon.Controls.OutlookGrid
 
         public int Add(object val)
         {
+            if (val == null)
+                return -1;
+
             return List.Add(val);
         }
 

--- a/src/Controls/OutlookGrid/OutlookGrid.cs
+++ b/src/Controls/OutlookGrid/OutlookGrid.cs
@@ -135,6 +135,9 @@ namespace Xnlab.SQLMon.Controls.OutlookGrid
         
         public override void Sort(DataGridViewColumn dataGridViewColumn, ListSortDirection direction)
         {
+            if (dataGridViewColumn == null)
+                return;
+
             if (_dataSource == null) // if no datasource is set, then bind to the grid itself
                 _dataSource = new DataSourceManager(this, null);
 

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -3487,7 +3487,7 @@ order by highest_cpu_queries.total_worker_time desc";
                         case AnalysisTypes.IndexUsage:
                         case AnalysisTypes.Performance:
                         case AnalysisTypes.LogicFault:
-                            text = dgvAnalysis.Rows[e.RowIndex].Cells["Suggestion"].Value.ToString();
+                            text = dgvAnalysis.Rows[e.RowIndex].Cells["Suggestion"].Value?.ToString();
                             break;
                         case AnalysisTypes.LockedObjects:
                             var spid = dgvAnalysis.Rows[e.RowIndex].Cells["SPID"].Value;


### PR DESCRIPTION
Low priority: The Xnlab.SQLMon.Common.Extensions [Invoke](https://github.com/unruledboy/SQLMonitor/blob/1744e5ca594ff99fb230e08e0d7808317ebd3b9a/src/Common/Extensions.cs#L20) method ignores these with an empty `catch {}`.

Visual Studio 2019 Debug > Windows > Exception Settings (Ctrl + Alt + E) enables 'Break When Thrown' for NullReferenceException by default, interrupting debugging sessions. 

    System.NullReferenceException
        System.Windows.Forms.DataGridViewCell.Value.get returned null.
       at Xnlab.SQLMon.UI.Monitor.OnAnalysisRowEnter(Object sender, DataGridViewCellEventArgs e) in src\UI\Monitor.cs:line 3490
    
    System.NullReferenceException
        dataGridViewColumn was null.
       at Xnlab.SQLMon.Controls.OutlookGrid.OutlookGrid.Sort(DataGridViewColumn dataGridViewColumn, ListSortDirection direction) in src\Controls\OutlookGrid\OutlookGrid.cs:line 141

    System.ArgumentNullException
      Value cannot be null.
    Parameter name: value
       at Xnlab.SQLMon.Controls.OutlookGrid.DataSourceRow.Add(Object val) in src\Controls\OutlookGrid\DataSourceManager.cs:line 80
       at Xnlab.SQLMon.Controls.OutlookGrid.DataSourceManager.InitGrid() in src\Controls\OutlookGrid\DataSourceManager.cs:line 178
       at Xnlab.SQLMon.Controls.OutlookGrid.DataSourceManager.InitManager() in src\Controls\OutlookGrid\DataSourceManager.cs:line 140
       at Xnlab.SQLMon.Controls.OutlookGrid.DataSourceManager..ctor(Object dataSource, String dataMember) in src\Controls\OutlookGrid\DataSourceManager.cs:line 106
       at Xnlab.SQLMon.Controls.OutlookGrid.OutlookGrid.Sort(DataGridViewColumn dataGridViewColumn, ListSortDirection direction) in src\Controls\OutlookGrid\OutlookGrid.cs:line 142
       at Xnlab.SQLMon.UI.Monitor.<>c__DisplayClass76_0.<OnMonitorEngineHealth>b__0() in src\UI\Monitor.cs:line 303

Tested on Windows 10.