### PR TITLE
Avoid SqlException "syntax near 'GO'": Also split version control object creation script on Unix line endings.

### DIFF
--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -1656,7 +1656,7 @@ GO
 ENABLE TRIGGER [{1}] ON DATABASE
 GO
 ", Settings.Instance.VersionControlTableName, Settings.Instance.VersionControlTriggerName);
-                        var statements = sql.Split(new string[] { "GO\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                        var statements = sql.Split(new string[] { "GO\r\n", "GO\n" }, StringSplitOptions.RemoveEmptyEntries);
                         statements.ForEach(s => SqlHelper.ExecuteNonQuery(s, CurrentServerInfo));
                     }
                 }


### PR DESCRIPTION
I managed to get files with Unix line endings, so the following code doesn't properly break up the script:

https://github.com/unruledboy/SQLMonitor/blob/2876264adafbd9f6c8e76eb489528127e84e5c12/src/UI/Monitor.cs#L1659

    System.Data.SqlClient.SqlException #102
      Message=Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
    Incorrect syntax near 'GO'.
       at Xnlab.SQLMon.Common.SqlHelper.ExecuteNonQuery(String sql, ServerInfo server) in src\Common\SQLHelper.cs:line 70
       at Xnlab.SQLMon.UI.Monitor.<SetVersionControl>b__157_0(String s) in src\UI\Monitor.cs:line 1660
       at Xnlab.SQLMon.Common.Extensions.ForEach[T](IEnumerable`1 source, Action`1 action) in src\Common\Extensions.cs:line 73
       at Xnlab.SQLMon.UI.Monitor.SetVersionControl(Boolean enable) in src\UI\Monitor.cs:line 1660
       at Xnlab.SQLMon.UI.Monitor.OnSetVersionControlClick(Object sender, EventArgs e) in src\UI\Monitor.cs:line 3950

Tested with Visual Studio 2019 on Windows 10.